### PR TITLE
Let MatchMaker use the javaParser passed in, instead of creating a new JavaParser.

### DIFF
--- a/src/main/java/com/vesperin/base/JavaParser.java
+++ b/src/main/java/com/vesperin/base/JavaParser.java
@@ -31,7 +31,7 @@ public interface JavaParser {
    * @throws RuntimeException if there is a parsing error.
    */
   default ParsedUnit parseJava(Context context){
-    for(ContextMatcher each : MatchMaker.generateUnitMatchers()){
+    for(ContextMatcher each : MatchMaker.generateUnitMatchers(this)){
       final ParsedUnit unit = each.matches(context);
       if(!unit.isEmptyUnit()){
         return unit;

--- a/src/main/java/com/vesperin/base/matchers/AbstractContextMatcher.java
+++ b/src/main/java/com/vesperin/base/matchers/AbstractContextMatcher.java
@@ -23,9 +23,9 @@ public abstract class AbstractContextMatcher implements ContextMatcher {
    *
    * @param mode the parsing mode.
    */
-  protected AbstractContextMatcher(int mode){
+  protected AbstractContextMatcher(int mode, JavaParser javaParser){
     this.mode     = mode;
-    this.parser   = new EclipseJavaParser();
+    this.parser   = javaParser;
   }
 
   protected static ParsedUnit bindProgramUnitToContext(Context context, ParsedUnit unit){

--- a/src/main/java/com/vesperin/base/matchers/MatchMaker.java
+++ b/src/main/java/com/vesperin/base/matchers/MatchMaker.java
@@ -1,6 +1,7 @@
 package com.vesperin.base.matchers;
 
 import com.vesperin.base.Context;
+import com.vesperin.base.JavaParser;
 import com.vesperin.base.ParsedUnit;
 import com.vesperin.utils.Immutable;
 import com.vesperin.base.Jdt;
@@ -22,20 +23,20 @@ public class MatchMaker {
     );
   }
 
-  public static List<ContextMatcher> generateUnitMatchers(){
+  public static List<ContextMatcher> generateUnitMatchers(JavaParser javaParser){
 
     final List<ContextMatcher> safeList = Arrays.asList(
-      new ValidCompilationUnitMatching(),
-      new MissingClassDeclaration(),
-      new MissingClassAndMethodBodyDeclarations()
+      new ValidCompilationUnitMatching(javaParser),
+      new MissingClassDeclaration(javaParser),
+      new MissingClassAndMethodBodyDeclarations(javaParser)
     );
 
     return Immutable.listOf(safeList);
   }
 
   static class ValidCompilationUnitMatching extends AbstractContextMatcher {
-    ValidCompilationUnitMatching() {
-      super(ASTParser.K_COMPILATION_UNIT);
+    ValidCompilationUnitMatching(JavaParser javaParser) {
+      super(ASTParser.K_COMPILATION_UNIT, javaParser);
     }
 
     @Override public ParsedUnit matches(Context context) {
@@ -56,8 +57,8 @@ public class MatchMaker {
   }
 
   static class MissingClassDeclaration extends AbstractContextMatcher {
-    MissingClassDeclaration(){
-      super(ASTParser.K_CLASS_BODY_DECLARATIONS);
+    MissingClassDeclaration(JavaParser javaParser){
+      super(ASTParser.K_CLASS_BODY_DECLARATIONS, javaParser);
     }
 
     @Override public ParsedUnit matches(Context context) {
@@ -76,8 +77,8 @@ public class MatchMaker {
   }
 
   static class MissingClassAndMethodBodyDeclarations extends AbstractContextMatcher {
-    MissingClassAndMethodBodyDeclarations(){
-      super(ASTParser.K_STATEMENTS);
+    MissingClassAndMethodBodyDeclarations(JavaParser javaParser){
+      super(ASTParser.K_STATEMENTS, javaParser);
     }
 
     @Override public ParsedUnit matches(Context context) {

--- a/src/test/java/com/vesperin/base/JavaParserTest.java
+++ b/src/test/java/com/vesperin/base/JavaParserTest.java
@@ -56,19 +56,19 @@ public class JavaParserTest {
   );
 
   private static final Source TypeAnnotatedNeedClassPathSRC = Source.from("Example",
-          String.join("\n",
-            Immutable.listOf(Arrays.asList(
-              ""
-              ,"import com.vesperin.base.TestingTypeAnnotation;"
-              ,""
-              ,"public class Example {"
-              , " public @TestingTypeAnnotation(TestingTypeAnnotation.TestEnumValue.TOP) int exit(){"
-              , "   return 1;"
-              , " }"
-              , "}"
-              ))
-                )
-        );
+    String.join("\n",
+      Immutable.listOf(Arrays.asList(
+        ""
+        ,"import com.vesperin.base.TestingTypeAnnotation;"
+        ,""
+        ,"public class Example {"
+        , " public @TestingTypeAnnotation(TestingTypeAnnotation.TestEnumValue.TOP) int exit(){"
+        , "   return 1;"
+        , " }"
+        , "}"
+        ))
+          )
+  );
 
   @Test public void testTypeAnnotation() throws Exception {
     final String expectedAnnotationStrValue = "Example.TestingAll(value=1)";
@@ -82,22 +82,22 @@ public class JavaParserTest {
 
       assertEquals(1, definition.getReturnType().getAnnotations().size());
       for (AnnotationDefinition annotationDefinition : definition.getReturnType().getAnnotations()) {
-          assertEquals(expectedAnnotationStrValue, annotationDefinition.toString());
+        assertEquals(expectedAnnotationStrValue, annotationDefinition.toString());
       }
     }
   }
 
   @Test public void testTypeAnnotationWithClassPath() throws Exception {
       final String expectedAnnotationStrValue =
-              "com.vesperin.base.TestingTypeAnnotation("
-              + "value=public static final com.vesperin.base.TestingTypeAnnotation.TestEnumValue TOP"
-              + ")";
+          "com.vesperin.base.TestingTypeAnnotation("
+          + "value=public static final com.vesperin.base.TestingTypeAnnotation.TestEnumValue TOP"
+          + ")";
 
       final String workingDir = System.getProperty("user.dir");
       final Context context = new JavaParserConfiguration()
-              .setClasspathEntries(Arrays.asList(Paths.get(workingDir, "bin").toString()))
-              .configure()
-              .parseJava(TypeAnnotatedNeedClassPathSRC);
+          .setClasspathEntries(Arrays.asList(Paths.get(workingDir, "bin").toString()))
+          .configure()
+          .parseJava(TypeAnnotatedNeedClassPathSRC);
 
       MethodDeclarationVisitor methodDeclarationVisitor = new MethodDeclarationVisitor();
       context.accept(methodDeclarationVisitor);
@@ -108,7 +108,7 @@ public class JavaParserTest {
 
         assertEquals(1, definition.getReturnType().getAnnotations().size());
         for (AnnotationDefinition annotationDefinition : definition.getReturnType().getAnnotations()) {
-            assertEquals(expectedAnnotationStrValue, annotationDefinition.toString());
+          assertEquals(expectedAnnotationStrValue, annotationDefinition.toString());
         }
       }
     }

--- a/src/test/java/com/vesperin/base/TestingTypeAnnotation.java
+++ b/src/test/java/com/vesperin/base/TestingTypeAnnotation.java
@@ -8,10 +8,10 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface TestingTypeAnnotation {
-    TestEnumValue[] value();
+  TestEnumValue[] value();
 
-    public enum TestEnumValue {
-        TOP;
-    }
+  public enum TestEnumValue {
+    TOP;
+  }
 }
 

--- a/src/test/java/com/vesperin/base/TestingTypeAnnotation.java
+++ b/src/test/java/com/vesperin/base/TestingTypeAnnotation.java
@@ -1,0 +1,17 @@
+package com.vesperin.base;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
+public @interface TestingTypeAnnotation {
+    TestEnumValue[] value();
+
+    public enum TestEnumValue {
+        TOP;
+    }
+}
+


### PR DESCRIPTION
As title described. This ensures `Matchers` parse the source code with the consistent settings in the client `javaParser` that uses these `Matchers`.